### PR TITLE
Added a basic check for the validity of an existing registration via rhn-channel -b

### DIFF
--- a/lib/puppet/provider/rhn_register/rhnreg_ks.rb
+++ b/lib/puppet/provider/rhn_register/rhnreg_ks.rb
@@ -53,12 +53,18 @@ Puppet::Type.type(:rhn_register).provide(:rhnreg_ks) do
   end
 
   def exists?
+    if @resource[:force] == true
+      Puppet.debug("Force registration is enabled")
+      return false
+    end
     Puppet.debug("Verifying if the server is already registered")
     if File.exists?("/etc/sysconfig/rhn/systemid")
-      if @resource[:force] == true
-        register
+      if system("rhn-channel -b")
+        return true
+      else
+        File.delete("/etc/sysconfig/rhn/systemid")
+        return false
       end
-      return true
     else
       return false
     end


### PR DESCRIPTION
We found that when a system is deleted from spacewalk, this puppet module does not detect that failure and re-register it. We added a simple check (base channel) to the exists? method to allow this to be validated. This has only been tested on our local environment (CentOS 6), but we believe it should generally work. We also moved the "force" check above the logic to test for a systemid file, and made it return false, which is more correct than executing register during the exists? check in our opinion.

~tommy