### PR TITLE
Add a new type for adding/removing channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PUPPET-RHNREG_KS
 
-This module provides Custom Puppet Provider to handle Red Hat Network
-Registering. It works with `RHN` or a `Red Hat Network Satellite` Server.
+This module provides Custom Puppet Providers to handle Red Hat Network
+Registering and subscribing to additional channels.
+It works with `RHN` or a `Red Hat Network Satellite` Server.
 
 ## License
 
@@ -13,13 +14,16 @@ Read Licence file for more information.
 ## Authors
 * Gaël Chamoulaud (gchamoul at redhat dot com)
 
-## Type and Provider
+## Types and Providers
 
 The module adds the following new types:
 
 * `rhn_register` for managing Red Hat Network Registering
+* `rhn_channel` for adding/removing channels
 
 ### Parameters
+
+#### rhn_register
 
 - **activationkeys**: The activation key to use when registering the system (cannot be used with username and password)
 - **ensure**: Valid values are `present`, `absent`. Default value is `present`.
@@ -36,6 +40,13 @@ The module adds the following new types:
 - **ssl_ca_cert**: Specify a file to use as the ssl CA cert
 - **username**: The username to use when registering the system
 - **virtinfo**: Whether or not virtualiztion information should be uploaded. Default value is `true`.
+
+#### rhn_channel
+
+- **channel** The channel to manage. (This is the namevar).
+- **ensure** Valid values are `present`, `absent`.
+- **username** The username to use when adding/removing a channel.
+- **password** The password to use when adding/removing a channel.
 
 ### Example
 
@@ -59,6 +70,16 @@ rhn_register { 'server.example.com':
   server_url     => 'https://xmlrpc.rhn.redhat.com/XMLRPC',
   ssl_ca_cert    => '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT',
   force          => true,
+}
+</pre>
+
+Adding a Channel:
+
+<pre>
+rhn_channel { 'centos6-scl-x86_64':
+  ensure   => present,
+  username => 'myusername',
+  password => 'mypassword',
 }
 </pre>
 

--- a/lib/facter/rhn_system_id.rb
+++ b/lib/facter/rhn_system_id.rb
@@ -1,0 +1,23 @@
+# rhn_system_id.rb
+require 'nokogiri'
+
+Facter.add(:rhn_system_id) do
+  confine :osfamily => 'RedHat'
+  setcode do
+    value = nil
+
+    filepath = '/etc/sysconfig/rhn/systemid'
+
+    if FileTest.file?(filepath)
+      begin
+        f = File.open(filepath)
+        doc = Nokogiri::XML(f)
+        f.close
+        value = doc.xpath("/params/param/value/struct/member[name='system_id']/value/string")[0].content
+      rescue
+        value = nil
+      end
+    end
+    value
+  end
+end

--- a/lib/puppet/provider/rhn_channel/rhn-channel.rb
+++ b/lib/puppet/provider/rhn_channel/rhn-channel.rb
@@ -1,0 +1,52 @@
+Puppet::Type.type(:rhn_channel).provide(:rhn_channel) do
+  confine :osfamily => :redhat
+
+  commands :rhn_channel => 'rhn-channel'
+
+  def self.instances
+    channels = rhn_channel('--list')
+    channels.split("\n").collect do |line|
+      new(:name   => line,
+          :ensure => :present
+         )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def build_parameters
+    if @resource[:username].nil? or @resource[:password].nil?
+      self.fail("username and password are required to add/remove channels")
+    end
+    params = []
+    params << "--channel=#{@resource[:name]}"
+    params << "--user=#{@resource[:username]}"
+    params << "--password=#{@resource[:password]}"
+    return params
+  end
+
+  def create
+    cmd = build_parameters
+    cmd << "--add"
+
+    rhn_channel(*cmd)
+  end
+
+  def destroy
+    cmd = build_parameters
+    cmd << "--remove"
+
+    rhn_channel(*cmd)
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+end

--- a/lib/puppet/type/rhn_channel.rb
+++ b/lib/puppet/type/rhn_channel.rb
@@ -1,0 +1,34 @@
+Puppet::Type.newtype(:rhn_channel) do
+  ensurable
+
+  newparam(:channel, :namevar => true) do
+    desc "The channel name."
+  end
+
+  newparam(:username) do
+    desc "The rhn/spacewalk user."
+    validate do |value|
+      #NB. Allowable usernames taken from spacewalk source code.
+      #username contains ascii chars minus whitespace, &, +, %, ', `, ", =, #
+      fail("Invalid username #{value}. Non ascii characters not permitted") unless /^[\x00-\x7F]+$/.match(value)
+      fail("Invalid username #{value}. Whitespace not permitted") if value =~ /\s/
+      illegal_chars = [ '&', '+', '%', '\'', '`', '"', '=', '#' ]
+      illegal_chars.each { |x|
+        fail("Invalid username #{value}. '#{x}' character not permitted") if value =~ /#{Regexp.escape(x)}/
+      }
+    end
+  end
+
+  newparam(:password) do
+    desc "The rhn/spacewalk password."
+  end
+
+  validate do
+    if self[:ensure] #Without this if, puppet resource rhn_channel will fail
+      if self[:password].nil? or self[:username].nil?
+        raise ArgumentError, 'username and password are required when adding or removing channels'
+      end
+    end
+  end
+
+end

--- a/spec/unit/puppet/type/rhn_channel_spec.rb
+++ b/spec/unit/puppet/type/rhn_channel_spec.rb
@@ -1,0 +1,50 @@
+require 'puppet'
+require 'puppet/type/rhn_channel'
+
+describe Puppet::Type.type(:rhn_channel) do
+
+  before :each do
+    @channel = Puppet::Type.type(:rhn_channel).new({:channel => 'foo', :username => 'user', :password => 'pass'})
+  end
+
+  it 'should accept a channel name' do
+    @channel[:channel].should == 'foo'
+  end
+
+  it 'should require a username when adding channel' do
+    expect {
+      Puppet::Type.type(:rhn_channel).new({:channel => 'foo', :ensure => 'present', :password => 'pass'})
+    }.to raise_error(/username and password are required when adding or removing channels/)
+  end
+
+  it 'should require a username when removing channel' do
+    expect {
+      Puppet::Type.type(:rhn_channel).new({:channel => 'foo', :ensure => 'absent', :password => 'pass'})
+    }.to raise_error(/username and password are required when adding or removing channels/)
+  end
+
+  it 'should fail with a username containing spaces' do
+    expect {
+      Puppet::Type.type(:rhn_channel).new({:channel => 'foo', :username => 'us er', :password => 'pass'})
+    }.to raise_error(/Invalid username us er. Whitespace not permitted/)
+  end
+
+  it 'should fail with a username containing a &' do
+    expect {
+      Puppet::Type.type(:rhn_channel).new({:channel => 'foo', :username => 'us&er', :password => 'pass'})
+    }.to raise_error(/Invalid username us&er. '&' character not permitted/)
+  end
+
+  it 'should require a password when adding channel' do
+    expect {
+      Puppet::Type.type(:rhn_channel).new({:channel => 'foo', :ensure => 'present', :username => 'user'})
+    }.to raise_error(/username and password are required when adding or removing channels/)
+  end
+
+  it 'should require a password when removing channel' do
+    expect {
+      Puppet::Type.type(:rhn_channel).new({:channel => 'foo', :ensure => 'absent', :username => 'user'})
+    }.to raise_error(/username and password are required when adding or removing channels/)
+  end
+
+end


### PR DESCRIPTION
Hi

I've added a new rhn_channel type/provider.  Username and password are mandatory.

rhn_channel { 'channel-name':
  username => 'user',
  password => 'password',
}

There's a unit test for the type.  I've also added a new fact which I found useful in my manifests.

Feedback and suggested improvements very welcome,
Alex