### PR TITLE
adding force_check option for server_url mismatches and re-registering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The module adds the following new types:
 - **activationkeys**: The activation key to use when registering the system (cannot be used with username and password)
 - **ensure**: Valid values are `present`, `absent`. Default value is `present`.
 - **force**: Should the registration be forced. Use this option with caution, setting it true will cause the rhnreg_ks command to be run every time runs. Default value `false`.
+- **force_check**: Should the registration be forced if the server_url on the current system has a mismatch with the one defined during the puppet run. Default value `false`.
 - **hardware**: Whether or not the hardware information should be probed. Default value is `true`.
 - **packages**: Whether or not packages information should be probed. Default value is `true`.
 - **password**: The password to use when registering the system

--- a/lib/puppet/type/rhn_register.rb
+++ b/lib/puppet/type/rhn_register.rb
@@ -43,7 +43,7 @@ Puppet::Type.newtype(:rhn_register) do
 
   newparam(:username) do
     desc "The username to use when registering the system"
-    
+
   end
 
   newparam(:password) do
@@ -88,6 +88,13 @@ Puppet::Type.newtype(:rhn_register) do
           runs."
 
     defaultto false
+  end
+
+  newparam(:force_check, :parent => Puppet::Property::Boolean) do
+  desc "Should the registration be forced if the server_url the system is
+        currently registered to differs from the one provided."
+
+   defaultto false
   end
 
   newparam(:proxy) do


### PR DESCRIPTION
Adding a check to allow users to force re-registering if the system is registered to a server_url that differs from that definition in the active resource.