### PR TITLE
Error handling for rhn_channel

### DIFF
--- a/lib/puppet/provider/rhn_channel/rhn-channel.rb
+++ b/lib/puppet/provider/rhn_channel/rhn-channel.rb
@@ -4,7 +4,12 @@ Puppet::Type.type(:rhn_channel).provide(:rhn_channel) do
   commands :rhn_channel => 'rhn-channel'
 
   def self.instances
-    channels = rhn_channel('--list')
+    begin
+      channels = rhn_channel('--list')
+    rescue Puppet::ExecutionFailure => e
+      Puppet.debug "#rhn_channel --list had an error -> #{e.inspect}"
+      return {}
+    end
     channels.split("\n").collect do |line|
       new(:name   => line,
           :ensure => :present


### PR DESCRIPTION
When we're not registered with spacewalk, rhn-channel --list exits non-zero.

Fixes: ```puppet resource rhn_channel```
```Error: Could not run: Execution of '/usr/sbin/rhn-channel --list'
returned 1: Unable to locate SystemId file. Is this system registered?```