### PR TITLE
adds a new function called rhn_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,36 @@ Read Licence file for more information.
 
 ## Authors
 * Gaël Chamoulaud (gchamoul at redhat dot com)
+* Corey Osman <corey@nwops.io>
+
+## Functions
+Note: the usage of this function requires the future parser or puppet 4
+
+rhn_keys - Allows you to build a complex list of rhn registration keys easily
+using facts and a key_map.  Returns a comma separated string of registration keys.
+
+```puppet
+# fact values that point to a registration key
+$rhn_registration_keys_map = {
+   'rhel6'    => '12393828293',
+   'physical' => '128283828',
+   'vmware'   => '3882838223',
+   'rhel7'    => '1383823923',
+   'location_1' => '23232323232'
+ }
+ # these should be fact names
+$rhn_registration_criteria = ['virtual', 'operatingsystemrelease', 'location']
+
+$reg_keys = rhn_keys($rhn_registration_keys_map, $rhn_registration_criteria, $::facts)
+
+rhn_register { $satellite_server:
+  activationkeys => $reg_keys,
+  server_url     => "https://${satellite_server}/XMLRPC",
+  ssl_ca_cert    => $rhn_server_cert_path,
+  force          => false,
+}
+
+```
 
 ## Types and Providers
 

--- a/lib/puppet/functions/rhn_keys.rb
+++ b/lib/puppet/functions/rhn_keys.rb
@@ -1,0 +1,30 @@
+# extremely helpful documentation
+# https://github.com/puppetlabs/puppet-specifications/blob/master/language/func-api.md#the-4x-api
+Puppet::Functions.create_function(:rhn_keys) do
+  dispatch :rhn_keys do
+    required_param 'Hash[String[1],String[1]]', :reg_map
+    required_param 'Array[String[1]]', :key_criteria
+    required_param 'Hash[String, Any]', :facts
+  end
+  # given a reg_map like:
+  # {
+  #   'rhel6' => '12393828293',
+  #   'physical' => '128283828',
+  #   'vmware'   => '3882838223',
+  #   'rhel7'    => '1383823923'
+  # }
+  # and a key_criteria ['virtual', 'operatingsystemrelease']
+  # Returns a comma seperated list of rhn registration keys by
+  # searching through the reg_map to find fact values that match
+  # the nodes fact value given the criteria
+  # produces output like: '12393828293,128283828'
+  def rhn_keys(reg_map, key_criteria,facts)
+    # loop around each key critera and query the reg_map to see
+    # if the fact value is associated with an RHN key
+    reg_keys = key_criteria.map do |fact|
+      reg_map[facts[fact]]
+    end
+    # for each RHN key found, join them into a single string separate by commas
+    reg_keys.compact.join(',')
+  end
+end

--- a/spec/functions/rhn_keys_spec.rb
+++ b/spec/functions/rhn_keys_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet/loaders'
+
+describe 'rhn_keys' do
+
+  let(:reg_map) do
+    {
+      'rhel6' => '12393828293',
+      'physical' => '128283828',
+      'vmware'   => '3882838223',
+      'rhel7'    => '1383823923'
+    }
+  end
+
+  let(:facts) do
+    {
+      'operatingsystemrelease' => 'unknown',
+      'virtual' => 'unknown'
+    }
+  end
+
+  let(:function_args) do
+    [reg_map, criteria, facts]
+  end
+
+  let(:criteria) do
+    ['virtual', 'operatingsystemrelease']
+  end
+
+  it 'should return an empty string' do
+    is_expected.to run.with_params(*function_args).and_return('')
+  end
+
+  it 'should raise error' do
+    is_expected.to run.with_params("ten",6).and_raise_error(ArgumentError, /expects 3 arguments, got 2/)
+  end
+
+  describe 'vmware' do
+    let(:facts) do
+      {
+        'operatingsystemrelease' => 'unknown',
+        'virtual' => 'vmware'
+      }
+    end
+    let(:return_value) do
+      '3882838223'
+    end
+    it 'should return data' do
+      is_expected.to run.with_params(*function_args).and_return(return_value)
+    end
+    describe 'rhel6' do
+      let(:facts) do
+        {
+          'operatingsystemrelease' => 'rhel6',
+          'virtual' => 'vmware'
+        }
+      end
+      let(:return_value) do
+        '3882838223,12393828293'
+      end
+      it 'should return data' do
+        is_expected.to run.with_params(*function_args).and_return(return_value)
+      end
+    end
+    describe 'rhel7' do
+      let(:facts) do
+        {
+          'operatingsystemrelease' => 'rhel7',
+          'virtual' => 'vmware'
+        }
+      end
+      let(:return_value) do
+        '3882838223,1383823923'
+      end
+      it 'should return data' do
+        is_expected.to run.with_params(*function_args).and_return(return_value)
+      end
+    end
+  end
+
+  describe 'physical' do
+    let(:facts) do
+      {
+        'operatingsystemrelease' => 'unknown',
+        'virtual' => 'physical'
+      }
+    end
+    let(:return_value) do
+      '128283828'
+    end
+    it 'should return data' do
+      is_expected.to run.with_params(*function_args).and_return(return_value)
+    end
+    describe 'rhel6' do
+      let(:facts) do
+        {
+          'operatingsystemrelease' => 'rhel6',
+          'virtual' => 'physical'
+        }
+      end
+      let(:return_value) do
+        '128283828,12393828293'
+      end
+      it 'should return data' do
+        is_expected.to run.with_params(*function_args).and_return(return_value)
+      end
+    end
+
+    describe 'rhel7' do
+      let(:facts) do
+        {
+          'operatingsystemrelease' => 'rhel7',
+          'virtual' => 'physical'
+        }
+      end
+      let(:return_value) do
+        '128283828,1383823923'
+      end
+      it 'should return data' do
+        is_expected.to run.with_params(*function_args).and_return(return_value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- returns a comma separate list of registration keys given
  some fact criteria.  Requires future parser or puppet 4.
